### PR TITLE
Limit proshort value to 5 charcters and lowercase letters

### DIFF
--- a/src/identitas/proquint.clj
+++ b/src/identitas/proquint.clj
@@ -3,7 +3,7 @@
 equivalent."
       :author "Phillip Lord"}
     identitas.proquint
-  (:require [clojure.string]
+  (:require [clojure.string :as str]
             [identitas.util :as u]
             [primitive.operator.integer :as i]))
 
@@ -123,7 +123,8 @@ equivalent."
 The JVM does not actually have a short datatype, so by short, we mean a number
 between 0 and 65535."
   [p]
-  (unchecked-short (proshort-to-short-1 p 0)))
+  (let [s (subs (str/lower-case p) 0 5)]
+  (unchecked-short (proshort-to-short-1 s 0))))
 
 (defn long-to-prolong
   ([l]


### PR DESCRIPTION
5 charcters; e.g "babab".
Uppercase proshort always give zero for any proshort value